### PR TITLE
add export for jetty-block extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+// This placeholder script allows this package to be discovered using require.resolve.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "asciidoctor-kroki": "latest",
     "@octokit/rest": "~20.0"
   },
+  "main": "./lib/index.js",
+  "exports": {
+    "./jetty-block": "./lib/jetty-block.js"
+  },
   "overrides": {
     "vinyl-fs": {
       "glob-stream": "~7.0"


### PR DESCRIPTION
This change is necessary to be able to use the jetty block extension from the branch build.

(In the future, this extension could be moved into its own repository and/or published to npm).