### PR TITLE
upgrade Collector and reconfigure the playbook template

### DIFF
--- a/lib/playbook-templates/per-branch-antora-playbook.yml
+++ b/lib/playbook-templates/per-branch-antora-playbook.yml
@@ -1,4 +1,4 @@
-# PACKAGES antora@testing gitlab:antora/antora-asciidoctor-extensions asciidoctor-kroki
+# PACKAGES antora@testing @antora/collector-extension gitlab:antora/antora-asciidoctor-extensions asciidoctor-kroki
 site:
   title: Eclipse Jetty Documentation (Branch Preview)
   start_page: jetty::index.adoc

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "The Antora playbook repository for the Eclipse Jetty website.",
   "private": true,
   "devDependencies": {
-    "antora": "latest",
-    "@antora/collector-extension": "latest",
+    "antora": "testing",
+    "@antora/collector-extension": "1.0.0-alpha.4",
     "@antora/lunr-extension": "latest",
     "antora-asciidoctor-extensions": "gitlab:antora/antora-asciidoctor-extensions",
     "asciidoctor-kroki": "latest",


### PR DESCRIPTION
- upgrade Collector to 1.0.0-alpha.4 and switch to a fixed version
- set up the branch playbook template to be able to activate the jetty block
- switch version of Antora to testing to add support for multiple worktrees when testing locally
- set log level to info in branch playbook template