### PR TITLE
upgrade Antora Collector; configure it to retain worktrees with Jetty Home until Antora exits

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,6 +13,9 @@ antora:
     require: '@antora/lunr-extension'
     enabled: false
     index_latest_only: true
+  - id: '@antora/collector-extension'
+    require: '@antora/collector-extension'
+    keep_worktrees: until:exit # Jetty Home is created in the temporary worktree, so retain until Antora exits
 runtime:
   log:
     destination:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "antora": "testing",
-    "@antora/collector-extension": "1.0.0-alpha.4",
+    "@antora/collector-extension": "1.0.0-beta.1",
     "@antora/lunr-extension": "latest",
     "antora-asciidoctor-extensions": "gitlab:antora/antora-asciidoctor-extensions",
     "asciidoctor-kroki": "latest",

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,6 @@
           <execution>
             <id>full</id>
             <configuration>
-              <environmentVariables>
-                <ANTORA_CACHE_DIR>${basedir}/.cache/antora</ANTORA_CACHE_DIR>
-              </environmentVariables>
               <additionalOptions>
                 <option>extension[] @antora/collector-extension</option>
                 <option>extension[] lunr</option>


### PR DESCRIPTION
Antora Collector now has a configuration option to keep temporary worktrees (in which Collector runs) until Antora exits. With this change, it's no longer necessary to rely on the Maven profile that installs Jetty Home into a directory outside the worktree. By not setting the ANTORA_CACHE_DIR environment variable, that profile will not be activated and it will just work.