### PR TITLE
Issue #60 fix 404 on 3 links in Contribution Guide

### DIFF
--- a/contribution-guide/modules/ROOT/pages/documentation/index.adoc
+++ b/contribution-guide/modules/ROOT/pages/documentation/index.adoc
@@ -51,7 +51,7 @@ If you _are_ interested in learning the ins and outs of AsciiDoc, the https://do
 
 TODO UPDATE FOR ANTORA
 
-In addition to using Maven to link:cg-build[build the Jetty codebase], we use it to build our docs.
+In addition to using Maven to xref:build/index.adoc[build the Jetty codebase], we use it to build our docs.
 During a build, Maven converts AsciiDoc-formatted docs into the HTML pages that you are reading right now.
 
 https://asciidoctor.org/[Asciidoctor] is the tool that actually performs this compilation step.
@@ -63,7 +63,7 @@ Maven integrates with Asciidoctor via the https://docs.asciidoctor.org/maven-too
 TODO UPDATE FOR ANTORA
 
 
-Since Jetty's docs are maintained in `git` alongside the rest of the Jetty codebase, you'll need to link:cg-source[check out a local copy] of the code to contribute to the docs.
+Since Jetty's docs are maintained in `git` alongside the rest of the Jetty codebase, you'll need to xref:source/index.adoc[check out a local copy] of the code to contribute to the docs.
 
 The docs are maintained as a separate module within Jetty, which means you can build the docs separately from the rest of the project.
 To do so, run `mvn clean install` from the `documentation/jetty-documentation` subdirectory.

--- a/contribution-guide/modules/ROOT/pages/patches/index.adoc
+++ b/contribution-guide/modules/ROOT/pages/patches/index.adoc
@@ -20,7 +20,7 @@ While not every contribution will be accepted, our commitment is to work with in
 [[cg-patches-git-config]]
 == Configuring `git`
 
-The email in your git commits must match the email you used to link:cg-eca[sign the Eclipse Contributor Agreement].
+The email in your git commits must match the email you used to xref:eca/index.adoc[sign the Eclipse Contributor Agreement].
 As such, you'll likely want to configure `user.email` in git accordingly.
 See link:https://help.github.com/articles/setting-your-email-in-git[this guide] on GitHub for details on how to do so.
 


### PR DESCRIPTION
Fix the 3 dangling links in Contribution Guide. Tested by running "mvn antora" and opening the file jetty.website/target/site/index.html in a browser.