### PR TITLE
Nowadays Jetty is built with Java 21

### DIFF
--- a/contribution-guide/modules/ROOT/pages/build/index.adoc
+++ b/contribution-guide/modules/ROOT/pages/build/index.adoc
@@ -26,7 +26,7 @@ Here are the minimum Maven and JDK version build requirements for each actively 
 |===
 | Branch | Maven Version | Minimum JDK | Recommended JDK
 
-| jetty-12.0.x | Maven 3.9.2+  | OpenJDK 17+ | OpenJDK 19
+| jetty-12.0.x | Maven 3.9.2+  | OpenJDK 17+ | OpenJDK 21
 | jetty-11.0.x | Maven 3.8.6+  | OpenJDK 11+ | OpenJDK 17
 | jetty-10.0.x | Maven 3.8.6+  | OpenJDK 11+ | OpenJDK 17
 |===


### PR DESCRIPTION
Java 19 is end-of-life, also the CI build runs with Java 21.